### PR TITLE
Adds file check to filesSrc filter

### DIFF
--- a/tasks/todo.js
+++ b/tasks/todo.js
@@ -46,7 +46,7 @@ module.exports = function( grunt ) {
 
     this.filesSrc.filter( function( filepath ) {
 
-      return grunt.file.exists( filepath );
+      return grunt.file.exists( filepath ) && grunt.file.isFile( filepath );
 
     } ).forEach( function( filepath ) {
       var results = [];


### PR DESCRIPTION
Hello,

I was running into an issue with `grunt todo` and nested folders.

```
$ grunt todo
Running "todo:default_options" (todo) task

webapp/app.js

  line 1  TODO  // TODO HI
Warning: Unable to read "webapp/controllers" file (Error code: EISDIR). Use --force to continue.

Aborted due to warnings.
```

Digging around, adding `grunt.file.isFile` fixed the issue.
