### PR TITLE
removes regex param from result print out

### DIFF
--- a/tasks/todo.js
+++ b/tasks/todo.js
@@ -13,6 +13,8 @@ var table = require( "text-table" );
 
 module.exports = function( grunt ) {
 
+  var strTest;
+
   grunt.registerMultiTask( "todo", "Find TODO, FIXME and NOTE inside project files", function() {
     var options = this.options( {
       marks: [
@@ -54,6 +56,10 @@ module.exports = function( grunt ) {
 
         marks.forEach( function( mark ) {
           if( mark.regex.test( line ) ) {
+
+            strTest = mark.regex.exec(line);
+            line = line.substring(strTest.index + strTest[0].length);
+            
             results.push( [
               chalk.gray( "\tline " + ( index + 1 ) ),
               chalk[ mark.color ]( mark.name ),


### PR DESCRIPTION
Hey again :)

I had another quick idea of removing the regex match from the string result. Currently it'll print something like this:

```
test/test.html

  line 93  TODO  <!-- TODO Hey, look ! I'm a todo in a TODO !!! -->

test/test.js

  line 17  TODO  // TODO Hey, i'm here !
  line 42  TODO  // TODO define method for AJAX request

test/test.styl

  line 26  TODO  // TODO add aliases for these
  line 30  BURP  // BURP Oops, sorry.
```

Removing the regex match would result in something like this:

```
test/test.html

  line 95  TODO  Hey, look ! I'm a todo in a TODO !!! -->

test/test.js

  line 17  TODO  Hey, i'm here !
  line 42  TODO  define method for AJAX request

test/test.styl

  line 26  TODO  add aliases for these
  line 30  BURP  Oops, sorry.
```

It doesn't remove the end of the HTML comment, but this will work without and context of what a valid line comment is.

What do you think? (I promise no more pull requests tonight)
