### PR TITLE
Feature/no logging option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 npm-debug.log
 tmp
-report.md
+report*.md

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,29 @@ module.exports = function(grunt) {
           'test/*'
         ],
       },
+      custom_options_no_logging: {
+        options: {
+          marks: [
+            {
+              pattern: "BURP",
+              color: "pink"
+            },
+            {
+              name: "TODO",
+              pattern: /TODO/,
+              color: "yellow"
+            }
+          ],
+          file: "report-2.md",
+          githubBoxes: true,
+          colophon: true,
+          usePackage: true,
+          logOutput: false
+        },
+        src: [
+          'test/*'
+        ],
+      },
     },
 
   });

--- a/src/todo.coffee
+++ b/src/todo.coffee
@@ -33,6 +33,7 @@ module.exports = ( grunt ) ->
             title: no
             colophon: no
             usePackage: no
+            logOutput: yes
         aAllowedColors = [
             "black"
             "red"
@@ -108,7 +109,7 @@ module.exports = ( grunt ) ->
 
                                 aFileResults.push "- #{ sGithubBox } **#{ oMark.name }** `(line #{ iIndex + 1 })` #{ sLine }" if oOptions.file
 
-                if aResults.length
+                if aResults.length and oOptions.logOutput
                     grunt.log.writeln()
                     grunt.log.writeln chalk.underline sFilePath
                     grunt.log.writeln()

--- a/tasks/todo.js
+++ b/tasks/todo.js
@@ -36,7 +36,8 @@ module.exports = function(grunt) {
       file: false,
       title: false,
       colophon: false,
-      usePackage: false
+      usePackage: false,
+      logOutput: true
     });
     aAllowedColors = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "gray"];
     sGithubBox = !!oOptions.githubBoxes ? " [ ]" : "";
@@ -123,7 +124,7 @@ module.exports = function(grunt) {
         }
         return _results;
       });
-      if (aResults.length) {
+      if (aResults.length && oOptions.logOutput) {
         grunt.log.writeln();
         grunt.log.writeln(chalk.underline(sFilePath));
         grunt.log.writeln();


### PR DESCRIPTION
Hey, first off: great plugin, find it really useful at work.

We're running it on watch, and the project has a lot of TODOs in it at the moment. I monitor the console output for errors etc, and we write the todo list to a versioned file so though it would be handy to have an option suppressing the console output.

I tried to follow your coding styles, added a test, and set the option to default to current behaviour.

What do you think? :)