### PR TITLE
Added options

### DIFF
--- a/src/todo.coffee
+++ b/src/todo.coffee
@@ -34,6 +34,7 @@ module.exports = ( grunt ) ->
             colophon: no
             usePackage: no
             logOutput: yes
+            ngdoc: false,
         aAllowedColors = [
             "black"
             "red"
@@ -59,6 +60,11 @@ module.exports = ( grunt ) ->
                 oOptions.usePackage = no
 
         if oOptions.file
+            if oOptions.ngdoc
+                aLogFileLines.push '@ngdoc overview'
+                aLogFileLines.push '@name ' + (if oOptions.title != '' then oOptions.title else sTitle)
+                aLogFileLines.push '@description'
+                aLogFileLines.push ''
             if sTitle = ( oOptions.title or ( if oOptions.usePackage and oProjectPackage.name then oProjectPackage.name else no ) or sDefaultTitle )
                 if oOptions.usePackage
                     if sHomePage = oProjectPackage.homepage

--- a/tasks/todo.js
+++ b/tasks/todo.js
@@ -37,7 +37,8 @@ module.exports = function(grunt) {
       title: false,
       colophon: false,
       usePackage: false,
-      logOutput: true
+      logOutput: true,
+      ngdoc: false
     });
     aAllowedColors = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "gray"];
     sGithubBox = !!oOptions.githubBoxes ? " [ ]" : "";
@@ -55,6 +56,12 @@ module.exports = function(grunt) {
       }
     }
     if (oOptions.file) {
+      if (oOptions.ngdoc) {
+        aLogFileLines.push('@ngdoc overview');
+        aLogFileLines.push('@name ' + (oOptions.title !== '' ? oOptions.title : sTitle));
+        aLogFileLines.push('@description');
+        aLogFileLines.push('');
+      }
       if (sTitle = oOptions.title || (oOptions.usePackage && oProjectPackage.name ? oProjectPackage.name : false) || sDefaultTitle) {
         if (oOptions.usePackage) {
           if (sHomePage = oProjectPackage.homepage) {


### PR DESCRIPTION
Don't know if this is something that people need.. but at least i found it useful, so i made quick fix to be able to ease the ngdoc generation for my TODO list.

Add ngdoc: true to options:{} and you can use the TODO list with grunt/gulp-ngdocs

